### PR TITLE
予約フォームメッセージ追加

### DIFF
--- a/src/app/Http/Controllers/ShopController.php
+++ b/src/app/Http/Controllers/ShopController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Auth;
 use DateTime;
 use DatePeriod;
 use DateInterval;
+use Carbon\Carbon;
 
 class ShopController extends Controller
 {
@@ -69,7 +70,9 @@ class ShopController extends Controller
 
             $counter = 1;
 
-            return view('user/mypage', compact('reservations', 'shops', 'counter'));
+            $today = Carbon::now()->format('Y-m-d');
+
+            return view('user/mypage', compact('reservations', 'shops', 'counter', 'today'));
         }
     }
 

--- a/src/public/css/user/detail.css
+++ b/src/public/css/user/detail.css
@@ -252,4 +252,8 @@
     .store-info__table {
         width: 100%;
     }
+
+    .reservation-form__date-input {
+        width: 100%;
+    }
 }

--- a/src/public/css/user/mypage.css
+++ b/src/public/css/user/mypage.css
@@ -51,14 +51,6 @@
     vertical-align: bottom;
 }
 
-.reservation__edit-btn {
-    margin: 8px auto 0;
-    color: #fff;
-    border: 1px solid #fff;
-    background-color: #4b6cf1;
-    font-size: 14px;
-}
-
 .reservation-status__table-header {
     width: 30%;
     text-align: left;
@@ -76,6 +68,19 @@
 .reservation__edit-btn {
     text-decoration: none;
     display: inline-block;
+    margin: 8px auto 0;
+    color: #fff;
+    border: 1px solid #fff;
+    background-color: #4b6cf1;
+    font-size: 14px;
+}
+
+.reservation__confirmed-btn {
+    display: inline-block;
+    margin: 8px auto 0;
+    color: #fff;
+    background-color: #e68332;
+    font-size: 14px;
 }
 
 .edit-icon {

--- a/src/resources/views/editor/reservation-list.blade.php
+++ b/src/resources/views/editor/reservation-list.blade.php
@@ -42,7 +42,7 @@
         @else
 
         @php
-            $list_item =($reservations->currentPage()-1)*$reservations->perPage()+1;
+            $list_item = 1;
         @endphp
 
         @foreach($reservations as $reservation)

--- a/src/resources/views/livewire/reservation-edit.blade.php
+++ b/src/resources/views/livewire/reservation-edit.blade.php
@@ -87,6 +87,11 @@
                     </tr>
                 </table>
             </div>
+            @if (session('error'))
+                <div class="flash_error-message">
+                    {{ session('error') }}
+                </div>
+            @endif
             <button class="reservation-form__submit" @if(!Auth::check()) disabled @endif wire:click="update({{ $reservation['id'] }})">
                 予約更新
             </button>

--- a/src/resources/views/livewire/reservation-form.blade.php
+++ b/src/resources/views/livewire/reservation-form.blade.php
@@ -91,6 +91,11 @@
                     </tr>
                 </table>
             </div>
+            @if (session('result'))
+                <div class="flash_error-message">
+                    {{ session('result') }}
+                </div>
+            @endif
             <button class="reservation-form__submit" type="submit" @if(!Auth::check()) disabled @endif>
                 予約する
             </button>

--- a/src/resources/views/user/detail.blade.php
+++ b/src/resources/views/user/detail.blade.php
@@ -83,6 +83,8 @@
     </table>
 </div>
 
-@livewire('reservation-form', ['option_times'=>$option_times, 'option_numbers'=>$option_numbers, 'shop'=>$shop])
+@livewire('reservation-form', ['option_times'=>$option_times,
+'option_numbers'=>$option_numbers,
+'shop'=>$shop])
 
 @endsection

--- a/src/resources/views/user/mypage.blade.php
+++ b/src/resources/views/user/mypage.blade.php
@@ -66,11 +66,19 @@
                     </td>
                 </tr>
             </table>
+            @if($reservation['date'] !== $today)
             <div class="reservation__edit-group">
                 <a class="common-btn reservation__edit-btn" href="#edit{{ $reservation['id'] }}">
                     <img class="edit-icon" src="../images/edit.svg" alt="pen">edit
                 </a>
             </div>
+            @else
+            <div class="reservation__edit-group">
+                <p class="common-btn reservation__confirmed-btn">
+                    確定
+                </p>
+            </div>
+            @endif
         </div>
 
         <div class="modal__group" id="{{ $reservation['id'] }}">


### PR DESCRIPTION
予約フォームメッセージ追加
    入力した予約データに対して、店舗の席数を超える場合やログインユーザーの予約日時が重複した場合、エラーメッセージを表示

mypage
　当日の予約変更不可
　ボタンをeditから確定に変わるようにした