### PR TITLE
メニュー登録機能修正

### DIFF
--- a/src/app/Http/Controllers/EditorController.php
+++ b/src/app/Http/Controllers/EditorController.php
@@ -174,7 +174,7 @@ class EditorController extends Controller
             $shop_id = null;
         }
 
-        return view('editor/menu-editor-form', compact('shop_id', 'menus'));
+        return view('editor/menu-editor-form', compact('shop_id', 'menus', 'user'));
     }
 
     public function postMenu(MenuRequest $request) {

--- a/src/public/css/editor/menu-editor-form.css
+++ b/src/public/css/editor/menu-editor-form.css
@@ -29,7 +29,7 @@
 }
 
 .menu-list__table {
-    width: auto;
+    width: 100%;
     border: 1px solid #929191;
     border-collapse: collapse;
     margin-top: 32px;

--- a/src/public/css/user/detail.css
+++ b/src/public/css/user/detail.css
@@ -96,7 +96,7 @@
     background-color: #305dff;
     display: flex;
     flex-direction: column;
-    height: 880px;
+    height: auto;
 }
 
 .reservation__title {
@@ -113,7 +113,7 @@
 }
 
 .reservation-form {
-    padding: 32px 28px 0;
+    padding: 32px 28px 150px;
     flex-grow: 1;
     position: relative;
 }
@@ -357,14 +357,13 @@
     }
 
     .reservation__group {
-        height: 880px;
         margin-top: 0;
         grid-column: 1/1;
         grid-row: 3/4;
     }
 
     .reservation-form {
-        padding: 32px 28px 0;
+        padding: 32px 28px 120px;
         position: relative;
     }
 

--- a/src/resources/views/editor/menu-editor-form.blade.php
+++ b/src/resources/views/editor/menu-editor-form.blade.php
@@ -6,6 +6,11 @@
 @endsection
 
 @section('content')
+@if($user->shopRepresentative == null)
+    <div class="flash_error-message">
+        先に店舗情報を登録してください
+    </div>
+@endif
 @if (session('result'))
     <div class="flash_success-message">
         {{ session('result') }}
@@ -64,7 +69,7 @@
         </table>
 
         <div class="store-edit__btn-group">
-            <a class="store-edit__btn" href="#editor">保存</a>
+            <a class="store-edit__btn" href="{{ $user->shopRepresentative == null ? '' : '#editor' }}">保存</a>
         </div>
 
         <div class="modal__group" id="editor">


### PR DESCRIPTION
メニュー登録機能修正
    店舗情報を新規作成する場合、先に店舗情報の登録が必要。
　店舗情報が未登録の場合にメニュー画面を開くとメッセージが表示され、メニュー登録ボタンが非活性になるようにした。

店舗予約フォームのcss修正